### PR TITLE
Fix filter method according to author's comment

### DIFF
--- a/src/OneEuroFilter.java
+++ b/src/OneEuroFilter.java
@@ -118,7 +118,7 @@ class OneEuroFilter {
         
         lasttime = timestamp;
         // estimate the current variation per second
-        double dvalue = x.hasLastRawValue() ? (value - x.lastRawValue()) * freq : value; // FIXME: 0.0 or value?
+        double dvalue = x.hasLastRawValue() ? (value - x.lastRawValue()) * freq : 0.0;
         double edvalue = dx.filterWithAlpha(dvalue, alpha(dcutoff));
         // use it to update the cutoff frequency
         double cutoff = mincutoff + beta_ * Math.abs(edvalue);


### PR DESCRIPTION
I contacted Casiez, the author of the 1€ filter paper, and asked about that FIXME line present in most implementations. He wrote that this value is the initial value when there are no previous data points, and that it should be 0.0 (because it's undefined) instead of value, and that the comment should be removed.